### PR TITLE
update doctest and fix compile by adding missing header stdexcept

### DIFF
--- a/tests/test_exceptions.cpp
+++ b/tests/test_exceptions.cpp
@@ -7,6 +7,7 @@
 
 #include "doctest/doctest.h"
 #include "tdp/pipeline.hpp"
+#include <stdexcept>
 
 struct thrower {
   int count = 0;


### PR DESCRIPTION
This fixes compile for tests and examples for me on gcc 13.2.0 Ubuntu 23.10
